### PR TITLE
Adds Login & Registration Components

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "history": "^4.9.0",
+    "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,15 @@
 import React from "react";
 import "./App.css";
 import Game from "./components/Game/Game";
+import Login from "./components/Login/Login";
+import Register from "./components/Register/Register";
+
 function App() {
   return (
     <div className="App">
       <Game />
+      <Login />
+      <Register />
     </div>
   );
 }

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,0 +1,68 @@
+import React, {Component} from "react";
+import axios from "axios";
+import config from "config";
+
+/**
+ * Login Component allows user to login to their existing account
+ * Sends credentials object to the API with a username and password
+ * Expects from the API a response with a key, validating they are a registered user
+ */
+
+class Login extends Component {
+    constructor() {
+        super();
+        this.state = {
+            username: "",
+            password: "",
+            loading: false
+        }
+    };
+
+    handleInput = e => {
+        this.setState({
+            [e.target.name]: e.target.value
+        })
+    };
+
+    handleSubmit = e => {
+        e.preventDefault();
+        const credentials = {
+            username: this.state.username,
+            password: this.state.password,
+        };
+
+        this.setState({
+            // TODO: Can add a loading spinner for improved UI
+            loading: true
+        });
+
+        axios.post(`${config.apiUrl}/api/login`, credentials)
+            .then( res => {
+                console.log(res);
+                // SET KEY TO localStorage?
+                // Verify return format of res {key: 12345}
+                localStorage.setItem("authToken", res.data.key);
+                // ROUTE TO GAME
+                this.setState({
+                    username: "",
+                    password: "",
+                });
+            })
+            .catch( err => {
+                console.err(err);
+                // TODO: Find out expected errors and format
+            })
+    }
+
+    render(){
+        return(
+            <form onSubmit={this.handleSubmit}>
+                <input onChange={this.handleInput} type="text" name="username" placeholder="Username" value={this.state.username}></input>
+                <input onChange={this.handleInput} type="password" name="password" placeholder="Password" value={this.state.password}></input>
+                <button type="submit">Login</button>
+            </form>
+        )
+    }
+};
+
+export default Login;

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 import axios from "axios";
-import config from "config";
+import config from "../../config/index";
 
 /**
  * Login Component allows user to login to their existing account
@@ -18,12 +18,21 @@ class Login extends Component {
         }
     };
 
+    /**
+     * handleInput sets user input to state, to accurately reflect their input and save for form submission
+     * @param: Event, that triggers the function from user action.
+     */
     handleInput = e => {
         this.setState({
             [e.target.name]: e.target.value
         })
     };
 
+    /**
+     * Submits user inputs to the API endpoint to login
+     * If successful, sets the user's key to localStorage. If unsuccessful, logs error.
+     * @param {*} Event that triggers the function from user submitting form
+     */
     handleSubmit = e => {
         e.preventDefault();
         const credentials = {
@@ -50,7 +59,7 @@ class Login extends Component {
                 // ROUTE TO GAME
             })
             .catch( err => {
-                console.err(err);
+                console.error(err);
                 // TODO: Find out expected errors and format
             })
     }

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -42,11 +42,12 @@ class Login extends Component {
                 // SET KEY TO localStorage?
                 // Verify return format of res {key: 12345}
                 localStorage.setItem("authToken", res.data.key);
-                // ROUTE TO GAME
                 this.setState({
                     username: "",
                     password: "",
+                    loading: false
                 });
+                // ROUTE TO GAME
             })
             .catch( err => {
                 console.err(err);

--- a/src/components/Register/Register.js
+++ b/src/components/Register/Register.js
@@ -1,6 +1,6 @@
 import React, {Component} from "react";
 import axios from "axios";
-import config from "config";
+import config from "../../config/index";
 
 /**
  * Register Component allowa a user to register for a new account
@@ -19,12 +19,21 @@ class Register extends Component {
         }
     };
 
+    /**
+     * handleInput sets user input to state, to accurately reflect their input and save for form submission
+     * @param: Event, that triggers the function from user action.
+     */
     handleInput = e => {
         this.setState({
             [e.target.name]: e.target.value
         })
     };
 
+    /**
+     * Submits user inputs to the API endpoint to register
+     * If successful, sets the user's key to localStorage. If unsuccessful, logs error.
+     * @param {*} Event that triggers the function from user submitting form
+     */
     handleSubmit = e => {
         e.preventDefault();
 
@@ -56,7 +65,7 @@ class Register extends Component {
                 // ROUTE TO GAME
             })
             .catch( err => {
-                console.err(err);
+                console.error(err);
                 // TODO: Find out expected errors and format
             })
     }

--- a/src/components/Register/Register.js
+++ b/src/components/Register/Register.js
@@ -47,12 +47,13 @@ class Register extends Component {
                 // SET KEY TO localStorage?
                 // Verify return format of res {key: 12345}
                 localStorage.setItem("authToken", res.data.key);
-                // ROUTE TO GAME
                 this.setState({
                     username: "",
                     password1: "",
-                    password2: ""
+                    password2: "",
+                    loading: false
                 });
+                // ROUTE TO GAME
             })
             .catch( err => {
                 console.err(err);

--- a/src/components/Register/Register.js
+++ b/src/components/Register/Register.js
@@ -1,0 +1,75 @@
+import React, {Component} from "react";
+import axios from "axios";
+import config from "config";
+
+/**
+ * Register Component allowa a user to register for a new account
+ * Sends a credentials object to the API with username, password1, and password2, where password1 and password2 should match
+ * Awaits an object response from API with a key to set to user's localStorage, to verify they are a valid registered user
+ */
+
+class Register extends Component {
+    constructor() {
+        super();
+        this.state = {
+            username: "",
+            password1: "",
+            password2: "",
+            loading: false
+        }
+    };
+
+    handleInput = e => {
+        this.setState({
+            [e.target.name]: e.target.value
+        })
+    };
+
+    handleSubmit = e => {
+        e.preventDefault();
+
+        // TODO: Verify passwords match
+        // TODO: Add any FE type checking for password security
+
+        const credentials = {
+            username: this.state.username,
+            password1: this.state.password1,
+            password2: this.state.password2
+        };
+
+        this.setState({
+            loading: true
+        });
+
+        axios.post(`${config.apiUrl}/api/registration`, credentials)
+            .then( res => {
+                console.log(res);
+                // SET KEY TO localStorage?
+                // Verify return format of res {key: 12345}
+                localStorage.setItem("authToken", res.data.key);
+                // ROUTE TO GAME
+                this.setState({
+                    username: "",
+                    password1: "",
+                    password2: ""
+                });
+            })
+            .catch( err => {
+                console.err(err);
+                // TODO: Find out expected errors and format
+            })
+    }
+
+    render(){
+        return(
+            <form onSubmit={this.handleSubmit}>
+                <input onChange={this.handleInput} type="text" name="username" placeholder="Username" value={this.state.username}></input>
+                <input onChange={this.handleInput} type="password" name="password1" placeholder="Password" value={this.state.password1}></input>
+                <input onChange={this.handleInput} type="password" name="password2" placeholder="Repeat Password" value={this.state.password2}></input>
+                <button type="submit">Register</button>
+            </form>
+        )
+    }
+};
+
+export default Register;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,0 +1,10 @@
+/**
+ * Creates a config object with commonly used URLs or keys throughout the application
+ * Allows for single spot updating of frequently used information across components
+ */
+
+export const config = {
+    apiUrl: "http://127.0.0.1:8000/"
+};
+
+export default config

--- a/yarn.lock
+++ b/yarn.lock
@@ -8097,7 +8097,7 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
-prop-types@^15.5.4:
+prop-types@^15.5.4, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
Description
- [x] Adds Register component that lets a user register credentials. Receives back a key and sets to localStorage
- [x] Adds Login component that lets a user login with existing credentials. Receives back a key and sets to localStorage
- [x] Adds config file for team consistent apiUrl variable to use across components, allowing quick updating of the API endpoint in one file.

Testing:
- [x] Passes Netlify check
- [ ] Team member reviewed

Known Bugs/Future Tickets:

- [ ] Need to add App Routing
- [ ] Need to add initial Authentication check on localStorage (to determine whether to route user to Game or Login/Registration)
- [ ] Need to update config with proper server endpoint when done by BE team
- [ ] Should create a single Login/Register page that easily swaps between the two options

